### PR TITLE
fix: allow parseDDL to recognize table names with dashes

### DIFF
--- a/ddlmod.go
+++ b/ddlmod.go
@@ -12,8 +12,8 @@ import (
 
 var (
 	sqliteSeparator    = "`|\"|'|\t"
-	indexRegexp        = regexp.MustCompile(fmt.Sprintf("CREATE(?: UNIQUE)? INDEX [%v]?[\\w\\d]+[%v]? ON (.*)$", sqliteSeparator, sqliteSeparator))
-	tableRegexp        = regexp.MustCompile(fmt.Sprintf("(?i)(CREATE TABLE [%v]?[\\w\\d]+[%v]?)(?: \\((.*)\\))?", sqliteSeparator, sqliteSeparator))
+	indexRegexp        = regexp.MustCompile(fmt.Sprintf("CREATE(?: UNIQUE)? INDEX [%v]?[\\w\\d-]+[%v]? ON (.*)$", sqliteSeparator, sqliteSeparator))
+	tableRegexp        = regexp.MustCompile(fmt.Sprintf("(?i)(CREATE TABLE [%v]?[\\w\\d-]+[%v]?)(?: \\((.*)\\))?", sqliteSeparator, sqliteSeparator))
 	separatorRegexp    = regexp.MustCompile(fmt.Sprintf("[%v]", sqliteSeparator))
 	columnsRegexp      = regexp.MustCompile(fmt.Sprintf("\\([%v]?([\\w\\d]+)[%v]?(?:,[%v]?([\\w\\d]+)[%v]){0,}\\)", sqliteSeparator, sqliteSeparator, sqliteSeparator, sqliteSeparator))
 	columnRegexp       = regexp.MustCompile(fmt.Sprintf("^[%v]?([\\w\\d]+)[%v]?\\s+([\\w\\(\\)\\d]+)(.*)$", sqliteSeparator, sqliteSeparator))

--- a/ddlmod_test.go
+++ b/ddlmod_test.go
@@ -42,6 +42,25 @@ func TestParseDDL(t *testing.T) {
 			{NameValue: sql.NullString{String: "text", Valid: true}, DataTypeValue: sql.NullString{String: "varchar(10)", Valid: true}, ColumnTypeValue: sql.NullString{String: "varchar(10)", Valid: true}, DefaultValueValue: sql.NullString{String: "测试，", Valid: true}, NullableValue: sql.NullBool{Valid: true}, UniqueValue: sql.NullBool{Valid: true}, PrimaryKeyValue: sql.NullBool{Valid: true}},
 		},
 		},
+		{
+			"table_name_with_dash",
+			[]string{
+				"CREATE TABLE `test-a` (`id` int NOT NULL)",
+				"CREATE UNIQUE INDEX `idx_test-a_id` ON `test-a`(`id`)",
+			},
+			1,
+			[]migrator.ColumnType{
+				{
+					NameValue:         sql.NullString{String: "id", Valid: true},
+					DataTypeValue:     sql.NullString{String: "int", Valid: true},
+					ColumnTypeValue:   sql.NullString{String: "int", Valid: true},
+					NullableValue:     sql.NullBool{Bool: false, Valid: true},
+					DefaultValueValue: sql.NullString{Valid: true},
+					UniqueValue:       sql.NullBool{Valid: true},
+					PrimaryKeyValue:   sql.NullBool{Valid: true},
+				},
+			},
+		},
 	}
 
 	for _, p := range params {


### PR DESCRIPTION
This fixes #44. The implementation is the same as @cncal used in https://github.com/go-gorm/sqlite/pull/104.
