### PR TITLE
ci: test against Go 1.24-1.26, matching upstream

### DIFF
--- a/.github/workflows/badge-gorm-tests.yml
+++ b/.github/workflows/badge-gorm-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: gorm-tests.yml
           workflow_conclusion: completed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ['1.21', '1.20', '1.19']
+        go: ['1.26', '1.25', '1.24']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/gorm-tests.yml
+++ b/.github/workflows/gorm-tests.yml
@@ -13,7 +13,7 @@ jobs:
   gorm-test:
     strategy:
       matrix:
-        go: ['1.20','1.19','1.18']
+        go: ['1.26', '1.25', '1.24']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
Second follow-up from #152. The current matrix fails on every branch for environmental reasons, visible on #153: Go ≤1.21 binaries abort with `missing LC_UUID load command` on current macos-latest runners, and Go ≤1.19 can't parse the `go 1.24.0` directive in gorm master's `tests/go.mod`, so the GORM-tests lane dies in the patch step before running a single test. All ubuntu lanes on #153 pass — the code is fine, the runners moved on.

Matches upstream's matrix (their `525c431`). Once this lands I'll rebase #153 on it so it gets a fully green run.

Refs #152